### PR TITLE
[Refactor] 投稿モデルの message 廃止と slides ベースへの移行

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -352,14 +352,9 @@ const docTemplate = `{
         "go-shisha-backend_internal_models.CreatePostInput": {
             "type": "object",
             "required": [
-                "message",
                 "user_id"
             ],
             "properties": {
-                "message": {
-                    "type": "string",
-                    "maxLength": 100
-                },
                 "slides": {
                     "type": "array",
                     "items": {
@@ -399,9 +394,6 @@ const docTemplate = `{
                 },
                 "likes": {
                     "type": "integer"
-                },
-                "message": {
-                    "type": "string"
                 },
                 "slides": {
                     "type": "array",

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -349,14 +349,9 @@
         "go-shisha-backend_internal_models.CreatePostInput": {
             "type": "object",
             "required": [
-                "message",
                 "user_id"
             ],
             "properties": {
-                "message": {
-                    "type": "string",
-                    "maxLength": 100
-                },
                 "slides": {
                     "type": "array",
                     "items": {
@@ -396,9 +391,6 @@
                 },
                 "likes": {
                     "type": "integer"
-                },
-                "message": {
-                    "type": "string"
                 },
                 "slides": {
                     "type": "array",

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -2,9 +2,6 @@ basePath: /api/v1
 definitions:
   go-shisha-backend_internal_models.CreatePostInput:
     properties:
-      message:
-        maxLength: 100
-        type: string
       slides:
         items:
           $ref: '#/definitions/go-shisha-backend_internal_models.Slide'
@@ -12,7 +9,6 @@ definitions:
       user_id:
         type: integer
     required:
-    - message
     - user_id
     type: object
   go-shisha-backend_internal_models.Flavor:
@@ -34,8 +30,6 @@ definitions:
         type: boolean
       likes:
         type: integer
-      message:
-        type: string
       slides:
         items:
           $ref: '#/definitions/go-shisha-backend_internal_models.Slide'

--- a/backend/internal/models/post.go
+++ b/backend/internal/models/post.go
@@ -14,7 +14,6 @@ type Slide struct {
 type Post struct {
 	ID        int       `json:"id"`
 	UserID    int       `json:"user_id"`
-	Message   string    `json:"message"`
 	Slides    []Slide   `json:"slides"`
 	Likes     int       `json:"likes"`
 	User      User      `json:"user"`
@@ -25,7 +24,6 @@ type Post struct {
 // CreatePostInput represents the input for creating a post
 type CreatePostInput struct {
 	UserID   int     `json:"user_id" binding:"required"`
-	Message  string  `json:"message" binding:"required,max=100"`
 	Slides   []Slide `json:"slides"`
 }
 

--- a/backend/internal/repositories/mock/post_repository_mock.go
+++ b/backend/internal/repositories/mock/post_repository_mock.go
@@ -23,7 +23,6 @@ func NewPostRepositoryMock() *PostRepositoryMock {
 			       {
 				       ID:       1,
 				       UserID:   1,
-				       Message:  "今日のシーシャは最高でした！ミント系のフレーバーが爽やかで最高",
 				       Slides: []models.Slide{
 					       {ImageURL: "/images/264971_0.jpg", Text: "最初はミント。爽やかでスッキリ！", Flavor: &mockFlavors[0]},
 					       {ImageURL: "/images/264972_0.jpg", Text: "次はダブルアップル。甘さが絶妙", Flavor: &mockFlavors[1]},
@@ -43,7 +42,6 @@ func NewPostRepositoryMock() *PostRepositoryMock {
 			       {
 				       ID:       2,
 				       UserID:   2,
-				       Message:  "新しいお店を発見！雰囲気も良くて味も抜群でした",
 				       Slides: []models.Slide{
 					       {ImageURL: "/images/264974_0.jpg", Text: "グレープの濃厚な香り", Flavor: &mockFlavors[3]},
 					       {ImageURL: "/images/264975_0.jpg", Text: "オレンジでリフレッシュ", Flavor: &mockFlavors[4]},
@@ -62,7 +60,6 @@ func NewPostRepositoryMock() *PostRepositoryMock {
 			       {
 				       ID:       3,
 				       UserID:   1,
-				       Message:  "ベリーの酸味がたまらない。ミックスもいいかも。",
 				       Slides: []models.Slide{
 					       {ImageURL: "/images/264977_0.jpg", Text: "ベリー単体で味わい深い", Flavor: &mockFlavors[2]},
 				       },
@@ -80,7 +77,6 @@ func NewPostRepositoryMock() *PostRepositoryMock {
 			       {
 				       ID:       4,
 				       UserID:   2,
-				       Message:  "マンゴーのトロピカル感が最高！ 夏にぴったり。",
 				       Slides: []models.Slide{
 					       {ImageURL: "/images/264978_0.jpg", Text: "マンゴーで夏気分", Flavor: &mockFlavors[5]},
 					       {ImageURL: "/images/264979_0.jpg", Text: "ミントでクールダウン", Flavor: &mockFlavors[0]},
@@ -99,7 +95,6 @@ func NewPostRepositoryMock() *PostRepositoryMock {
 			       {
 				       ID:       5,
 				       UserID:   1,
-				       Message:  "オレンジの爽やかさがいい感じ。リフレッシュできる〜",
 				       Slides: []models.Slide{
 					       {ImageURL: "/images/264975_0.jpg", Text: "オレンジで元気チャージ", Flavor: &mockFlavors[4]},
 				       },
@@ -117,7 +112,6 @@ func NewPostRepositoryMock() *PostRepositoryMock {
 			       {
 				       ID:       6,
 				       UserID:   2,
-				       Message:  "グレープの濃厚な味わい。フルーツ系の中でも特におすすめ！",
 				       Slides: []models.Slide{
 					       {ImageURL: "/images/264976_0.jpg", Text: "グレープで濃厚な一服", Flavor: &mockFlavors[3]},
 					       {ImageURL: "/images/264977_0.jpg", Text: "レモンでさっぱり", Flavor: &mockFlavors[2]},

--- a/backend/internal/services/post_service.go
+++ b/backend/internal/services/post_service.go
@@ -49,7 +49,6 @@ func (s *PostService) CreatePost(input *models.CreatePostInput) (*models.Post, e
 
        post := &models.Post{
 	       UserID:  input.UserID,
-	       Message: input.Message,
 	       Slides:  input.Slides,
 	       User:    *user,
        }

--- a/frontend/api/model/goShishaBackendInternalModelsCreatePostInput.ts
+++ b/frontend/api/model/goShishaBackendInternalModelsCreatePostInput.ts
@@ -9,8 +9,6 @@
 import type { GoShishaBackendInternalModelsSlide } from "./goShishaBackendInternalModelsSlide";
 
 export interface GoShishaBackendInternalModelsCreatePostInput {
-  /** @maxLength 100 */
-  message: string;
   slides?: GoShishaBackendInternalModelsSlide[];
   user_id: number;
 }

--- a/frontend/api/model/goShishaBackendInternalModelsPost.ts
+++ b/frontend/api/model/goShishaBackendInternalModelsPost.ts
@@ -14,7 +14,6 @@ export interface GoShishaBackendInternalModelsPost {
   id?: number;
   is_liked?: boolean;
   likes?: number;
-  message?: string;
   slides?: GoShishaBackendInternalModelsSlide[];
   user?: GoShishaBackendInternalModelsUser;
   user_id?: number;

--- a/frontend/features/posts/components/PostCard/PostCard.interactions.test.tsx
+++ b/frontend/features/posts/components/PostCard/PostCard.interactions.test.tsx
@@ -1,17 +1,17 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, test, expect, vi } from "vitest";
+import type { Post } from "@/types/domain";
 import { PostCard } from "./PostCard";
 
-const mockPost = {
+const mockPost: Post = {
   id: 1,
   slides: [
     { image_url: "https://example.com/a.jpg", text: "A" },
     { image_url: "https://example.com/b.jpg", text: "B" },
   ],
   user: { display_name: "u" },
-  message: "m",
-} as unknown as Record<string, unknown>;
+};
 
 describe("PostCard interactions", () => {
   test("Prev/Next ボタンでスライドが切り替わる", async () => {
@@ -19,7 +19,7 @@ describe("PostCard interactions", () => {
     render(<PostCard post={mockPost} onLike={onLike} />);
 
     // 初期は A が表示
-    expect(screen.getByText("A") || screen.getByText("m")).toBeTruthy();
+    expect(screen.getByText("A")).toBeTruthy();
 
     const next = screen.getByLabelText("次のスライド");
     await userEvent.click(next);

--- a/frontend/features/posts/components/PostCard/PostCard.stories.tsx
+++ b/frontend/features/posts/components/PostCard/PostCard.stories.tsx
@@ -5,7 +5,6 @@ import { PostCard } from ".";
 const mockPost: Post = {
   id: 1,
   user_id: 1,
-  message: "今日のシーシャは最高でした！ミント系のフレーバーが爽やかで最高",
   slides: [
     {
       image_url: "https://placehold.co/400x600/CCCCCC/666666?text=Mint",
@@ -31,7 +30,6 @@ const mockPost: Post = {
 const mockPostWithoutFlavor: Post = {
   id: 2,
   user_id: 2,
-  message: "新しいお店を発見！雰囲気も良くて味も抜群でした",
   slides: [
     {
       image_url: "https://placehold.co/400x600/CCCCCC/666666?text=Shisha",
@@ -157,7 +155,6 @@ export const WithoutImage: Story = {
     post: {
       ...mockPost,
       id: 4,
-      message: "画像なしの投稿です。フォールバック画像が表示されます。",
       slides: [
         {
           image_url: undefined,
@@ -179,7 +176,6 @@ export const MultipleSlides: Story = {
     post: {
       id: 5,
       user_id: 1,
-      message: "複数画像スライド",
       slides: [
         {
           image_url: "https://placehold.co/400x600/4CAF50/FFFFFF?text=Slide+1+Mint",
@@ -232,7 +228,6 @@ export const FiveSlides: Story = {
     post: {
       id: 6,
       user_id: 1,
-      message: "5枚の画像スライド",
       slides: [
         {
           image_url: "https://placehold.co/400x600/4CAF50/FFFFFF?text=1",
@@ -280,7 +275,6 @@ export const ProgressBarStatic: Story = {
     post: {
       id: 7,
       user_id: 1,
-      message: "プログレスバー表示確認（VRT用）",
       slides: [
         {
           image_url: "https://placehold.co/400x600/4CAF50/FFFFFF?text=1",

--- a/frontend/features/posts/components/PostCard/PostCard.test.tsx
+++ b/frontend/features/posts/components/PostCard/PostCard.test.tsx
@@ -7,7 +7,6 @@ import { PostCard } from ".";
 const mockPost: Post = {
   id: 1,
   user_id: 1,
-  message: "今日のシーシャは最高でした！",
   slides: [
     {
       image_url: "https://picsum.photos/400/600?random=1",
@@ -243,10 +242,9 @@ describe("PostCard", () => {
     expect(flavorBadge).toHaveClass("bg-gray-500");
   });
 
-  it("post.messageがundefinedの場合、alt属性がデフォルト値になる", () => {
-    const postWithoutMessage = {
+  it("スライドのテキストが空の場合、alt属性がデフォルト値になる", () => {
+    const postWithoutMessage: Post = {
       ...mockPost,
-      message: undefined,
       slides: [
         {
           image_url: "https://picsum.photos/400/600?random=1",
@@ -560,9 +558,9 @@ describe("PostCard", () => {
   });
 
   test("slidesが空の場合、デフォルト画像が表示される", () => {
-    const mockPost = { id: 1, slides: [], user_id: 1, message: "No slides" };
+    const mockPost = { id: 1, slides: [], user_id: 1 };
     render(<PostCard post={mockPost} onLike={() => {}} />);
-    const fallbackImage = screen.getByAltText("No slides");
+    const fallbackImage = screen.getByAltText("シーシャ投稿");
     expect(fallbackImage).toBeInTheDocument();
     // Next.js ImageがURLをエンコードするため、srcにplacehold.coが含まれていることを確認
     expect(fallbackImage.getAttribute("src")).toContain("placehold.co");
@@ -572,7 +570,6 @@ describe("PostCard", () => {
     const mockPostNoSlides: Partial<Post> = {
       id: 2,
       user_id: 2,
-      message: "No slides prop",
       // slides を意図的に含めない
     };
 
@@ -581,7 +578,7 @@ describe("PostCard", () => {
       <PostCard post={mockPostNoSlides as unknown as Post} onLike={() => {}} />
     );
 
-    const fallbackImage = screen.getByAltText("No slides prop");
+    const fallbackImage = screen.getByAltText("シーシャ投稿");
     expect(fallbackImage).toBeInTheDocument();
     expect(fallbackImage.getAttribute("src")).toContain("placehold.co");
   });

--- a/frontend/features/posts/components/PostCard/PostCard.tsx
+++ b/frontend/features/posts/components/PostCard/PostCard.tsx
@@ -122,7 +122,7 @@ export function PostCard({ post, onLike, onUnlike, autoPlayInterval = 3000 }: Po
   // 現在のスライドデータ
   const currentSlide = slides.length > 0 ? slides[currentSlideIndex] : undefined;
   const displayImageUrl = getImageUrl(currentSlide?.image_url);
-  const displayText = currentSlide?.text || post.message || "";
+  const displayText = currentSlide?.text || "";
   const displayFlavor = currentSlide?.flavor;
 
   return (

--- a/frontend/features/posts/components/PostDetail/PostDetail.stories.tsx
+++ b/frontend/features/posts/components/PostDetail/PostDetail.stories.tsx
@@ -17,7 +17,6 @@ const queryClient = new QueryClient({
 
 const mockPost: Post = {
   id: 1,
-  message: "これはサンプルの投稿メッセージです。\n長いテキストは改行されることを確認します。",
   created_at: new Date().toISOString(),
   likes: 12,
   is_liked: false,
@@ -38,7 +37,7 @@ const mockPost: Post = {
       flavor: { id: 2, name: "Grape" },
     },
   ],
-} as unknown as Post;
+};
 
 const meta = {
   title: "Features/Posts/PostDetail",

--- a/frontend/features/posts/components/PostDetail/PostDetail.test.tsx
+++ b/frontend/features/posts/components/PostDetail/PostDetail.test.tsx
@@ -36,7 +36,6 @@ vi.mock("next/image", () => {
 const mockPost: Post = {
   id: 11,
   user_id: 2,
-  message: "テスト投稿",
   slides: [
     {
       image_url: "https://placehold.co/400x600",
@@ -156,7 +155,7 @@ describe("PostDetail", () => {
 
     const refetch = vi.fn();
     (useGetPostsId as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
-      data: { id: 2, slides: [], user_id: 1, message: "No slides", likes: 0 },
+      data: { id: 2, slides: [], user_id: 1, likes: 0 },
       isLoading: false,
       isError: false,
       refetch,
@@ -344,7 +343,6 @@ describe("PostDetail", () => {
         id: 2,
         likes: 0,
         user: undefined,
-        message: "m",
       } as unknown as Post,
       isLoading: false,
       isError: false,

--- a/frontend/features/posts/components/PostDetail/PostDetail.tsx
+++ b/frontend/features/posts/components/PostDetail/PostDetail.tsx
@@ -101,7 +101,6 @@ export function PostDetail({ postId, initialPost }: PostDetailProps) {
           <PostDetailHeader user={post.user} createdAt={post.created_at} onBack={handleBack} />
 
           <PostDetailFooter
-            post={post}
             currentSlide={currentSlide}
             optimisticLikes={optimisticLikes}
             isLiked={isLiked}

--- a/frontend/features/posts/components/PostDetail/PostDetailFooter.tsx
+++ b/frontend/features/posts/components/PostDetail/PostDetailFooter.tsx
@@ -9,24 +9,17 @@ interface Slide {
   flavor?: Flavor;
 }
 
-interface Post {
-  id?: number;
-  message?: string | null;
-  user?: { display_name?: string; icon_url?: string } | null;
-}
-
 interface Props {
-  post: Post;
   currentSlide?: Slide | undefined;
   optimisticLikes: number;
   isLiked: boolean;
   onLike: () => void;
 }
 
-export function PostDetailFooter({ post, currentSlide, optimisticLikes, isLiked, onLike }: Props) {
+export function PostDetailFooter({ currentSlide, optimisticLikes, isLiked, onLike }: Props) {
   return (
     <div className="md:w-96">
-      <p className="mb-4 whitespace-pre-wrap">{currentSlide?.text || post.message}</p>
+      <p className="mb-4 whitespace-pre-wrap">{currentSlide?.text}</p>
 
       {currentSlide?.flavor && (
         <div className="mb-4">

--- a/frontend/features/posts/components/Timeline/Timeline.stories.tsx
+++ b/frontend/features/posts/components/Timeline/Timeline.stories.tsx
@@ -13,7 +13,6 @@ const mockPosts: Post[] = [
   {
     id: 1,
     user_id: 1,
-    message: "今日のシーシャは最高でした！ミント系のフレーバーが爽やかで最高",
     slides: [
       {
         image_url: "https://placehold.co/400x600/CCCCCC/666666?text=Mint",
@@ -38,7 +37,6 @@ const mockPosts: Post[] = [
   {
     id: 2,
     user_id: 2,
-    message: "新しいお店を発見！雰囲気も良くて味も抜群でした",
     slides: [
       {
         image_url: "https://placehold.co/400x600/CCCCCC/666666?text=Apple",
@@ -63,7 +61,6 @@ const mockPosts: Post[] = [
   {
     id: 3,
     user_id: 1,
-    message: "ベリーの酸味がたまらない。ミックスもいいかも。",
     slides: [
       {
         image_url: "https://placehold.co/400x600/CCCCCC/666666?text=Berry",
@@ -88,7 +85,6 @@ const mockPosts: Post[] = [
   {
     id: 4,
     user_id: 2,
-    message: "マンゴーのトロピカル感が最高！ 夏にぴったり。",
     slides: [
       {
         image_url: "https://placehold.co/400x600/CCCCCC/666666?text=Mango",

--- a/frontend/features/posts/components/Timeline/Timeline.test.tsx
+++ b/frontend/features/posts/components/Timeline/Timeline.test.tsx
@@ -13,7 +13,6 @@ const mockPosts: Post[] = [
   {
     id: 1,
     user_id: 1,
-    message: "今日のシーシャは最高でした！",
     slides: [
       {
         image_url: "https://picsum.photos/400/600?random=1",
@@ -35,7 +34,6 @@ const mockPosts: Post[] = [
   {
     id: 2,
     user_id: 2,
-    message: "新しいお店を発見！",
     slides: [
       {
         image_url: "https://picsum.photos/400/600?random=2",
@@ -142,8 +140,16 @@ describe("Timeline", () => {
 
   test("postsがある場合、タイムラインに投稿が表示される", () => {
     const mockPosts = [
-      { id: 1, slides: [], user_id: 1, message: "投稿1" },
-      { id: 2, slides: [], user_id: 2, message: "投稿2" },
+      {
+        id: 1,
+        slides: [{ image_url: "https://example.com/1.jpg", text: "投稿1" }],
+        user_id: 1,
+      },
+      {
+        id: 2,
+        slides: [{ image_url: "https://example.com/2.jpg", text: "投稿2" }],
+        user_id: 2,
+      },
     ];
     render(<Timeline posts={mockPosts} />);
     expect(screen.getByText("投稿1")).toBeInTheDocument();


### PR DESCRIPTION
## 概要
<!-- このPRで何を実現するのか、簡潔に説明してください -->
投稿モデルから廃止された `message` フィールドを削除し、スライド毎の `slides[].text` を利用するようにフロントエンドのテスト・モック・ドキュメントを修正します。

## 関連Issue
<!-- 関連するIssueがあれば記載してください。Issueを自動でCloseしたい場合は以下の形式を使用 -->
Closes #67

## 変更内容
- [x] リファクタリング
- [x] テスト追加・修正
- [x] ドキュメント修正

## 主な変更箇所
### Frontend
- `features/posts` のテスト・モックを `post.message` 依存から `slides[].text` へ切り替え。
- Story / テスト内のモックデータを更新し、VRT に差分が出ないことを確認。

### Backend
- （本PRはフロント寄りの変更です。バックエンドのモデル・OpenAPI更新が別途必要な場合は Issue #67 で扱います）

## 動作確認
- [x] ローカル環境での動作確認（Vitest 全テスト通過）
- [x] VRT 実行・差分なし

## スクリーンショット・動画
（該当なし）

## テスト
### 追加したテスト
- 既存テストの修正により `post.message` を参照しないようにしました。

### テスト結果
- [x] 全てのテストが通過

## 破壊的変更
- [ ] 破壊的変更なし（バックエンドの OpenAPI を更新する場合は破壊的変更の可能性あり。Issue #67 参照）

## レビューポイント
- フロントエンドのモック更新が正しく、UIに影響がないこと
- OpenAPI / 型生成が同期していない場合の修正方針（必要なら指示ください）

## 補足
- バックエンドで `Message` 型を削除する場合は `make swagger` → OpenAPI 更新 → フロントの型再生成 を行います。必要ならこのPRでその作業も行います。

## チェックリスト
- [x] コードレビューの準備ができている
- [x] 適切なラベルを付けている（既存ラベルを使用）
- [x] セルフレビューを実施している
