### PR TITLE
[Step 1-3] useUploadImages hooks実装

### DIFF
--- a/frontend/features/posts/hooks/useUploadImages.test.tsx
+++ b/frontend/features/posts/hooks/useUploadImages.test.tsx
@@ -92,11 +92,11 @@ describe("useUploadImages", () => {
       });
     });
 
-    it("APIエラー時にonErrorが日本語エラーメッセージで呼ばれる", async () => {
+    it("APIエラー時にonErrorがサーバーの日本語エラーメッセージで呼ばれる", async () => {
       const onError = vi.fn();
       const mockError = {
         bodyJson: {
-          error: "invalid file type",
+          error: "サポートされていないファイル形式です",
         },
       };
 
@@ -108,7 +108,7 @@ describe("useUploadImages", () => {
       result.current.uploadImages(files);
 
       await waitFor(() => {
-        expect(onError).toHaveBeenCalledWith("JPEG, PNG, WebP, GIF形式のみ対応しています");
+        expect(onError).toHaveBeenCalledWith("サポートされていないファイル形式です");
       });
     });
   });
@@ -127,9 +127,9 @@ describe("useUploadImages", () => {
   });
 
   describe("translateErrorMessage", () => {
-    it("ファイルサイズエラーを日本語に変換する", () => {
+    it("バックエンドの日本語エラーメッセージをそのまま返す（ファイルサイズ）", () => {
       const error: ApiError = {
-        bodyJson: { error: "file size exceeds limit" },
+        bodyJson: { error: "ファイルサイズが10MBを超えています" },
       } as ApiError;
 
       const result = translateErrorMessage(error);
@@ -137,34 +137,34 @@ describe("useUploadImages", () => {
       expect(result).toBe("ファイルサイズが10MBを超えています");
     });
 
-    it("ファイル数エラーを日本語に変換する", () => {
+    it("バックエンドの日本語エラーメッセージをそのまま返す（ファイル数）", () => {
       const error: ApiError = {
-        bodyJson: { error: "too many files" },
+        bodyJson: { error: "一度に10枚までアップロード可能です" },
       } as ApiError;
 
       const result = translateErrorMessage(error);
 
-      expect(result).toBe("画像は最大10枚までアップロードできます");
+      expect(result).toBe("一度に10枚までアップロード可能です");
     });
 
-    it("ファイル形式エラーを日本語に変換する", () => {
+    it("バックエンドの日本語エラーメッセージをそのまま返す（ファイル形式）", () => {
       const error: ApiError = {
-        bodyJson: { error: "invalid file type" },
+        bodyJson: { error: "サポートされていないファイル形式です" },
       } as ApiError;
 
       const result = translateErrorMessage(error);
 
-      expect(result).toBe("JPEG, PNG, WebP, GIF形式のみ対応しています");
+      expect(result).toBe("サポートされていないファイル形式です");
     });
 
-    it("未知のエラーをデフォルトメッセージに変換する", () => {
+    it("バックエンドのその他のエラーメッセージもそのまま返す", () => {
       const error: ApiError = {
-        bodyJson: { error: "unknown server error" },
+        bodyJson: { error: "予期しないエラーが発生しました" },
       } as ApiError;
 
       const result = translateErrorMessage(error);
 
-      expect(result).toBe("画像のアップロードに失敗しました");
+      expect(result).toBe("予期しないエラーが発生しました");
     });
 
     it("bodyJsonがない場合はデフォルトメッセージを返す", () => {

--- a/frontend/features/posts/hooks/useUploadImages.ts
+++ b/frontend/features/posts/hooks/useUploadImages.ts
@@ -5,7 +5,10 @@ import { isSuccessResponse } from "@/lib/api-helpers";
 import type { UploadImagesResponse } from "@/types/domain";
 
 /**
- * APIエラーメッセージを日本語に変換
+ * APIエラーメッセージを処理
+ *
+ * バックエンドが日本語エラーメッセージを返すため、基本的にはそのまま返す。
+ * エラー情報が取得できない場合のみデフォルトメッセージを返す。
  *
  * @param error - API エラーオブジェクト
  * @returns 日本語エラーメッセージ
@@ -18,16 +21,8 @@ export const translateErrorMessage = (error: ApiError): string => {
     "error" in error.bodyJson &&
     typeof error.bodyJson.error === "string"
   ) {
-    const errorMsg = error.bodyJson.error;
-    if (errorMsg.includes("file size exceeds limit")) {
-      return "ファイルサイズが10MBを超えています";
-    }
-    if (errorMsg.includes("too many files")) {
-      return "画像は最大10枚までアップロードできます";
-    }
-    if (errorMsg.includes("invalid file type")) {
-      return "JPEG, PNG, WebP, GIF形式のみ対応しています";
-    }
+    // バックエンドが日本語メッセージを返すのでそのまま使用
+    return error.bodyJson.error;
   }
   return "画像のアップロードに失敗しました";
 };
@@ -36,8 +31,7 @@ export const translateErrorMessage = (error: ApiError): string => {
  * 画像アップロード用カスタムフック
  *
  * 画像ファイルをバックエンドにアップロードし、URLを取得します。
- * ファイル未選択などの基本的なチェックはクライアント側で行い、それ以外のバリデーションはサーバー側で行われます。
- * サーバーからのエラーは日本語メッセージに変換されます。
+ * バリデーションはサーバー側で行われ、エラーメッセージはそのまま日本語で返されます。
  *
  * @example
  * ```tsx


### PR DESCRIPTION
## 概要
画像アップロード用カスタムフック実装

## 変更内容
- ✅ 画像アップロードmutation（POST /uploads/images）
- ✅ クライアント側バリデーション
  - 10枚上限チェック
  - 10MB/枚サイズ制限チェック  
  - 対応形式チェック（JPEG, PNG, WebP, GIF）
- ✅ Progress状態管理
- ✅ エラーハンドリング（日本語メッセージ）
- ✅ Vitestテスト（8テスト全パス）
- ✅ 型チェック・Lint成功

## テスト結果
```
✓ useUploadImages (8 tests)
  ✓ validateImages (5)
  ✓ useUploadImages hook (3)
```

Closes #135