### PR TITLE
CI（render-gif）に日本語フォントを追加し文字化けを修正

### DIFF
--- a/.github/workflows/render-gif.yml
+++ b/.github/workflows/render-gif.yml
@@ -64,7 +64,8 @@ jobs:
             libxrandr2 \
             libxcomposite1 \
             libxdamage1 \
-            libxfixes3
+            libxfixes3 \
+            fonts-noto-cjk
 
       - name: Install dependencies (frontend)
         working-directory: ./frontend


### PR DESCRIPTION
## 概要

CI（Ubuntu環境）に日本語フォントが未インストールだったため、プロモGIF動画のテキストが文字化け（豆腐）していた問題を修正。

## 関連Issue

Closes #

## 変更内容

- [ ] 機能追加
- [x] バグ修正  
- [ ] リファクタリング
- [ ] テスト追加・修正
- [ ] ドキュメント修正
- [ ] 設定・環境変更
- [ ] その他

## 主な変更箇所

### その他

- `.github/workflows/render-gif.yml`: `apt-get install` に `fonts-noto-cjk` を追加
  - Ubuntu CI環境にNoto CJKフォントをインストールすることで、Remotionが日本語テキストを正しくレンダリングできるようにした

## 動作確認

- [ ] ローカル環境での動作確認
- [ ] テストの実行・通過確認
- [ ] API動作確認（該当する場合）
- [ ] UI動作確認（該当する場合）
- [x] 既存機能への影響確認

## スクリーンショット・動画

CI実行後のGIF確認予定。

## テスト

### 追加したテスト
- なし（CI設定変更のみ）

### テスト結果
- [ ] 全てのテストが通過
- [ ] 新規テストを追加
- [ ] 既存テストの修正

## 破壊的変更

- [ ] 破壊的変更あり
- [x] 破壊的変更なし

## レビューポイント

- `fonts-noto-cjk` は `apt-get install` で取得できる標準パッケージ
- CI実行時間が若干増加するが、日本語フォントのインストールは初回のみキャッシュ対象外

## 補足

Remotion のレンダリングは Chromium (Headless) を使って行われるが、Ubuntu CI にはデフォルトで CJK フォントが含まれていないため、日本語文字が豆腐（□）になっていた。

## チェックリスト

- [x] コードレビューの準備ができている
- [x] 適切なラベルを付けている
- [ ] 必要に応じてドキュメントを更新している

*-- by Copilot*
