### PR TITLE
プロモ動画にMP4レンダリングを追加

### DIFF
--- a/.github/workflows/render-gif.yml
+++ b/.github/workflows/render-gif.yml
@@ -21,6 +21,9 @@ jobs:
   render:
     name: Render Promo GIF & MP4
     runs-on: ubuntu-latest
+    env:
+      # Remotion で Chromium サンドボックスを無効化（CI環境に必要）
+      REMOTION_NO_SANDBOX: "1"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -78,9 +81,6 @@ jobs:
             --codec=gif \
             --scale=0.5 \
             --gl=angle
-        env:
-          # Remotion で Chromium サンドボックスを無効化（CI環境に必要）
-          REMOTION_NO_SANDBOX: "1"
 
       - name: Render Promo MP4
         working-directory: ./frontend
@@ -89,8 +89,6 @@ jobs:
             --codec=h264 \
             --scale=0.5 \
             --gl=angle
-        env:
-          REMOTION_NO_SANDBOX: "1"
 
       - name: Show rendered file info
         run: ls -lh docs/demo.gif docs/demo.mp4


### PR DESCRIPTION
## 概要
CI の Remotion レンダリングワークフローに MP4 生成を追加。従来の GIF に加え、`docs/demo.mp4` も自動生成してリポジトリにコミットするよう変更。

## 関連Issue
なし

## 変更内容
- [ ] 機能追加
- [ ] バグ修正  
- [ ] リファクタリング
- [ ] テスト追加・修正
- [ ] ドキュメント修正
- [x] 設定・環境変更
- [ ] その他

## 主な変更箇所
### その他
- `.github/workflows/render-gif.yml`
  - ワークフロー名・ジョブ名を `Render Promo GIF & MP4` に変更
  - `Render Promo MP4` ステップを追加（`--codec=h264`、`--scale=0.5`）
  - `Show rendered file info` で `docs/demo.mp4` もサイズ確認するよう変更
  - コミット対象に `docs/demo.mp4` を追加

## 動作確認
- [ ] ローカル環境での動作確認
- [ ] テストの実行・通過確認
- [ ] API動作確認（該当する場合）
- [ ] UI動作確認（該当する場合）
- [x] 既存機能への影響確認（GIF生成には変更なし）

## スクリーンショット・動画
なし（CI ワークフローの変更のみ）

## テスト
### 追加したテスト
- なし（CI ワークフロー設定変更）

### テスト結果
- [ ] 全てのテストが通過
- [ ] 新規テストを追加
- [ ] 既存テストの修正

## 破壊的変更
- [ ] 破壊的変更あり
- [x] 破壊的変更なし

## レビューポイント
- MP4 レンダリングステップが GIF の後に順次実行されるため、CI 実行時間が増加（約2倍）。GitHub Actions の `ubuntu-latest` runner でタイムアウトしないか確認をお願いします
- `--codec=h264` 以外のオプション（`--scale`、`--gl`）は GIF と同一設定にしています
- `REMOTION_NO_SANDBOX: "1"` は CI 環境に必要なため MP4 ステップにも設定しています

## 補足
- `concurrency.cancel-in-progress: true` 設定により、連続 push 時に古い run が自動キャンセルされます
- MP4 は HTML の `<video>` タグで埋め込み可能なため、`docs/index.html` での活用も今後検討できます

## チェックリスト
- [x] コードレビューの準備ができている
- [x] 適切なラベルを付けている
- [ ] 必要に応じてドキュメントを更新している
- [x] セルフレビューを実施している
