### PR TITLE
fix: REDIRECT_SECRETのビルド時依存を除去し起動時バリデーションを追加 #244

### DIFF
--- a/frontend/instrumentation.ts
+++ b/frontend/instrumentation.ts
@@ -1,0 +1,6 @@
+// サーバー起動時に1回だけ実行される（next build 時は実行されない）
+export async function register() {
+  if (!process.env.REDIRECT_SECRET) {
+    throw new Error("REDIRECT_SECRET is not set. Please set it as a runtime environment variable.");
+  }
+}

--- a/frontend/lib/redirectCrypto.ts
+++ b/frontend/lib/redirectCrypto.ts
@@ -6,11 +6,6 @@ const IV_LENGTH = 12;
 
 const SECRET = process.env.REDIRECT_SECRET;
 
-if (!SECRET) {
-  console.error("REDIRECT_SECRET is not set");
-  throw new Error("REDIRECT_SECRET not set");
-}
-
 function base64urlEncode(bytes: Uint8Array): string {
   let binary = "";
   const len = bytes.byteLength;


### PR DESCRIPTION
## 概要

closes #244

`redirectCrypto.ts` のモジュールレベルの `throw` が `next build` 時にページデータ収集で実行されビルドが失敗していた問題を修正。

## 変更内容

- `frontend/lib/redirectCrypto.ts`: トップレベルの `throw` を削除（各関数内のガードは保持）
- `frontend/instrumentation.ts`: サーバー起動時の `REDIRECT_SECRET` 未設定を即検知

## バリデーションの流れ

| タイミング | 動作 |
|---|---|
| `docker build` 時 | `REDIRECT_SECRET` 不要・ビルド成功 |
| コンテナ起動時 | `instrumentation.ts` が未設定なら即クラッシュ |
| リクエスト時 | `encryptRedirect()` 内のガードで二重チェック |

## 原因

以前は `frontend/.env` に `REDIRECT_SECRET` が書かれていてビルドコンテキストに含まれていたため偶然ビルドが通っていた。#242 の env ファイル整理で `frontend/.env.local` がコンテキストから除外されたことで顕在化。

🤖 Generated with [Claude Code](https://claude.com/claude-code)